### PR TITLE
remove geoip.joinplayer_callback callback and docs

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -68,9 +68,6 @@ local function format_result(result)
 end
 
 -- function(name, result, last_login)
-geoip.joinplayer_callback = function() end
-
--- function(name, result, last_login)
 local on_joinplayer_handlers = {}
 function geoip.register_on_joinplayer(fn)
 	table.insert(on_joinplayer_handlers, fn)
@@ -102,8 +99,6 @@ minetest.register_on_joinplayer(function(player, last_login)
 				return
 			end
 		end
-		-- execute function override callback
-		geoip.joinplayer_callback(name, data, last_login)
 	end)
 end)
 

--- a/readme.md
+++ b/readme.md
@@ -33,11 +33,6 @@ geoip.lookup("213.152.186.35", function(result)
 	-- see "Geoip result data"
 end)
 
--- overrideable callback on player join
-geoip.joinplayer_callback = function(playername, result, last_login)
-	-- see "Geoip result data"
-end
-
 -- event handler registration, `return true` will prevent overrideable callback and rest of event handlers to be called
 geoip.register_on_joinplayer(function(playername, result, last_login)
 	-- see "Geoip result data"


### PR DESCRIPTION
I know we didn't deprecate the api-call but i would still favor removal of old/outdated ~~crap~~code