### PR TITLE
Chat command utilizes caches + cache cleanup timer

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -57,7 +57,7 @@ function geoip.lookup(ip, callback, playername)
 				result.status = data.status
 				result.description = data.description
 				result.timestamp = minetest.get_us_time()
-				result.players = playername and {playername=1} or {}
+				result.players = playername and {[playername]=1} or {}
 				cache[ip] = result
 				callback(result)
 				return

--- a/init.lua
+++ b/init.lua
@@ -17,23 +17,29 @@ minetest.register_privilege("geoip", {
 	give_to_singleplayer = false
 })
 
-local cache_ttl = tonumber(minetest.settings:get("geoip.cache.ttl")) or 3600
+-- Default TTL for cached results: 3 hours
+local cache_ttl = tonumber(minetest.settings:get("geoip.cache.ttl")) or 10800
 local cache = {}
 
-local function cleanup()
+-- Execute cache cleanup every cache_ttl seconds
+local function cache_cleanup()
 	local expire = minetest.get_us_time() - (cache_ttl * 1000 * 1000)
 	for ip, data in pairs(cache) do
 		if expire > data.timestamp then
 			cache[ip] = nil
 		end
 	end
+	minetest.after(cache_ttl, cache_cleanup)
 end
+minetest.after(cache_ttl, cache_cleanup)
 
-function geoip.lookup(ip, callback)
+-- Main geoip lookup function, callback function gets result table as first argument
+function geoip.lookup(ip, callback, playername)
 	if cache[ip] then
-		-- Might return expired entries but that should not really matter here
+		if playername and not cache[ip].players[playername] then
+			cache[ip].players[playername] = 1
+		end
 		callback(cache[ip])
-		cleanup()
 		return
 	end
 	http.fetch({
@@ -51,6 +57,7 @@ function geoip.lookup(ip, callback)
 				result.status = data.status
 				result.description = data.description
 				result.timestamp = minetest.get_us_time()
+				result.players = playername and {playername=1} or {}
 				cache[ip] = result
 				callback(result)
 				return
@@ -142,8 +149,18 @@ minetest.register_on_joinplayer(function(player, last_login)
 				return
 			end
 		end
-	end)
+	end, name)
 end)
+
+local function report_result(name, param, result)
+	local txt = format_result(result)
+	if not txt then
+		minetest.chat_send_player(name, "Geoip error: " .. (result.description or "unknown error"))
+		return
+	end
+	minetest.log("action", "[geoip] result for player " .. param .. ": " .. txt)
+	minetest.chat_send_player(name, txt)
+end
 
 -- manual query
 minetest.register_chatcommand("geoip", {
@@ -160,22 +177,22 @@ minetest.register_chatcommand("geoip", {
 
 		local ip = minetest.get_player_ip(param)
 
-		if not ip then
-			return true, "no ip available!"
-		end
-
-		geoip.lookup(ip, function(result)
-			local txt = format_result(result)
-
-			if not txt then
-				minetest.chat_send_player(name, "Geoip error: " .. (result.description or "unknown error"))
-				return
+		if ip then
+			-- go through lookup if ip is available, this might still return cached result 
+			geoip.lookup(ip, function(result)
+				report_result(name, param, result)
+			end, param)
+		else
+			for _, result in pairs(cache) do
+				for playername in pairs(result.players) do
+					if playername == param then
+						report_result(name, param, result)
+						return
+					end
+				end
 			end
-
-			minetest.log("action", "[geoip] result for player " .. param .. ": " .. txt)
-
-			minetest.chat_send_player(name, txt)
-		end)
+			return true, "no ip or cached result available!"
+		end
 
 	end
 })

--- a/init.lua
+++ b/init.lua
@@ -184,11 +184,9 @@ minetest.register_chatcommand("geoip", {
 			end, param)
 		else
 			for _, result in pairs(cache) do
-				for playername in pairs(result.players) do
-					if playername == param then
-						report_result(name, param, result)
-						return
-					end
+				if result.players[param] then
+					report_result(name, param, result)
+					return
 				end
 			end
 			return true, "no ip or cached result available!"

--- a/init.lua
+++ b/init.lua
@@ -178,7 +178,7 @@ minetest.register_chatcommand("geoip", {
 		local ip = minetest.get_player_ip(param)
 
 		if ip then
-			-- go through lookup if ip is available, this might still return cached result 
+			-- go through lookup if ip is available, this might still return cached result
 			geoip.lookup(ip, function(result)
 				report_result(name, param, result)
 			end, param)


### PR DESCRIPTION
Closes #11 

* Increases default cache TTL from 1 hour to 3 hours.
* Uses timer to cleanup caches, frequency is TTL so by default every 3 hours.
* Stores player names with cached geoip results.
* Chat command `/geoip playername` checks cached results if player is not online anymore.

I've not tested anything.

Chat command returns only first result from caches for single player.
Multiple cached results for single player name are very much possible, better behavior would be to return all results sorted by timestamp.