### PR TITLE
Sort & report all cached matches

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,7 +1,19 @@
 Copyright 2022 mt-mods and affiliates
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/init.lua
+++ b/init.lua
@@ -153,7 +153,7 @@ minetest.register_on_joinplayer(function(player, last_login)
 	end, name)
 end)
 
-local function format_result(name, result)
+local function format_message(name, result)
 	local txt = format_result(result)
 	if not txt then
 		return "Geoip error: " .. (result.description or "unknown error")
@@ -180,7 +180,7 @@ minetest.register_chatcommand("geoip", {
 		if ip then
 			-- go through lookup if ip is available, this might still return cached result
 			geoip.lookup(ip, function(result)
-				minetest.chat_send_player(name, format_result(param, result))
+				minetest.chat_send_player(name, format_message(param, result))
 			end, param)
 		else
 			local formatted_results = {}
@@ -189,7 +189,7 @@ minetest.register_chatcommand("geoip", {
 				if result.players[param] then
 					table.insert(formatted_results, {
 						time = now - result.players[param],
-						txt = format_result(param, result)
+						txt = format_message(param, result)
 					})
 				end
 			end

--- a/init.lua
+++ b/init.lua
@@ -95,14 +95,15 @@ local function format_result(result)
 	end
 end
 
--- function(name, result, last_login)
 local on_joinplayer_handlers = {}
 function geoip.register_on_joinplayer(fn)
+	assert(type(fn) == "function", "geoip.register_on_joinplayer expects function as a first argument")
 	table.insert(on_joinplayer_handlers, fn)
 end
 
 local on_prejoinplayer_handlers = {}
 function geoip.register_on_prejoinplayer(fn)
+	assert(type(fn) == "function", "geoip.register_on_prejoinplayer expects function as a first argument")
 	table.insert(on_prejoinplayer_handlers, fn)
 end
 

--- a/init.lua
+++ b/init.lua
@@ -178,7 +178,7 @@ local function format_matches_by_name(name)
 	end
 	if count > 0 then
 		table.sort(formatted_results, function(a,b)
-			return a.time > b.time
+			return a.time < b.time
 		end)
 		local msg = ""
 		for i = 1, count do

--- a/init.lua
+++ b/init.lua
@@ -162,7 +162,7 @@ local function format_message(name, result)
 	return txt
 end
 
-local function format_matches_by_name(name) {
+local function format_matches_by_name(name)
 	local formatted_results = {}
 	local now = minetest.get_us_time()
 	local count = 0
@@ -189,7 +189,7 @@ local function format_matches_by_name(name) {
 		end
 		return msg
 	end
-}
+end
 
 -- manual query
 minetest.register_chatcommand("geoip", {

--- a/readme.md
+++ b/readme.md
@@ -12,8 +12,11 @@ powered by [IP Location Finder by KeyCDN](https://tools.keycdn.com/geo)
 
 ### minetest.conf
 ```
-# enable curl/http on that mod
+# enable curl/http on that mod, required for geoip mod
 secure.http_mods = geoip
+
+# geoip result cache time-to-live value, default is 3 hours
+geoip.cache.ttl = 10800
 ```
 
 ### Commands
@@ -28,14 +31,31 @@ secure.http_mods = geoip
 # Api
 
 ```lua
--- lookup command
+-- Geoip lookup command
 geoip.lookup("213.152.186.35", function(result)
-	-- see "Geoip result data"
+	-- See "Geoip result data"
 end)
 
--- event handler registration, `return true` will prevent overrideable callback and rest of event handlers to be called
+-- Event handler registration
 geoip.register_on_joinplayer(function(playername, result, last_login)
-	-- see "Geoip result data"
+  -- See "Geoip result data" for example result.
+  if result.asn == 65535 then
+    minetest.after(0, function()
+      minetest.kick_player(playername, "No joining from reserved unused ASN")
+    end)
+    -- Return `true` to stop event handler propagation, should be used if player will be forcibly disconnected
+    return true
+  end
+end)
+
+-- Event handler registration
+geoip.register_on_prejoinplayer(function(playername, result, last_login, auth_data)
+  -- Only called if data is alre4ady cached.
+  -- See "Geoip result data" for example result.
+  if result.asn == 65535 then
+    -- Return string to disconnect player with that string as a reason.
+    return "No joining from reserved unused ASN"
+  end
 end)
 ```
 

--- a/spec/fail_spec.lua
+++ b/spec/fail_spec.lua
@@ -5,6 +5,7 @@ mineunit("player")
 mineunit("common/after")
 mineunit("server")
 mineunit("http")
+mineunit("auth")
 
 fixture("geoip_server")
 

--- a/spec/init_spec.lua
+++ b/spec/init_spec.lua
@@ -5,6 +5,7 @@ mineunit("player")
 mineunit("common/after")
 mineunit("server")
 mineunit("http")
+mineunit("auth")
 
 fixture("geoip_server")
 


### PR DESCRIPTION
~Bit messy and wont search for other records if player is online but only if ip isn't available.~

~So could be improved for sure, does this seem acceptable?~

Edit: Fixed it and now it does finds multiple matches also for online players and output is same no matter if player is available or not.

Might kill server or something, I've no idea... would be good to do some simple testing first.

Closes #13 